### PR TITLE
improvement for speed and clarity

### DIFF
--- a/rake_nltk/rake.py
+++ b/rake_nltk/rake.py
@@ -163,8 +163,8 @@ class Rake(object):
 
            @param sentences: List of strings where each string represents a
            sentence which forms the text.
-           @return: List of List of strings where each sublist is a collection
-           of words which form the contender phrase.
+           @return: Set of string tuples where each tuple is a collection
+           of words forming a contender phrase.
         '''
         phrase_list = set()
         # Create contender phrases from sentences.
@@ -182,7 +182,7 @@ class Rake(object):
            List of words: ['red', 'apples', ",", 'are', 'good', 'in', 'flavour']
            List after dropping punctuations and stopwords.
            List of words: ['red', 'apples', *, *, good, *, 'flavour']
-           List of phrases: [['red', 'apples'], ['good'], ['flavour']]
+           List of phrases: [('red', 'apples'), ('good',), ('flavour',)]
 
            @param word_list: List of words which form a sentence when joined in
            the same order.

--- a/rake_nltk/rake.py
+++ b/rake_nltk/rake.py
@@ -166,20 +166,12 @@ class Rake(object):
            @return: List of List of strings where each sublist is a collection
            of words which form the contender phrase.
         '''
-        phrase_list = []
+        phrase_list = set()
         # Create contender phrases from sentences.
         for sentence in sentences:
             word_list = [word.lower() for word in wordpunct_tokenize(sentence)]
-            phrase_list.extend(self._get_phrase_list_from_words(word_list))
-        # Drop duplicates from the list.
-        unique_phrase_list = []
-        seen = defaultdict(lambda: False)
-        for phrase in phrase_list:
-            phrase_str = ' '.join(phrase)
-            if not seen[phrase_str]:
-                seen[phrase_str] = True
-                unique_phrase_list.append(phrase)
-        return unique_phrase_list
+            phrase_list.update(self._get_phrase_list_from_words(word_list))
+        return phrase_list
 
     def _get_phrase_list_from_words(self, word_list):
         '''Method to create contender phrases from the list of words that form a
@@ -200,5 +192,5 @@ class Rake(object):
         phrase_list = []
         for group in groupby(word_list, lambda x: x in self.to_ignore):
             if not group[0]:
-                phrase_list.append(list(group[1]))
+                phrase_list.append(tuple(group[1]))
         return phrase_list

--- a/tests/rake_test.py
+++ b/tests/rake_test.py
@@ -100,6 +100,7 @@ class RakeUnitTest(unittest.TestCase):
             'compatibility'
         ]
         self.assertEqual(r.get_ranked_phrases(), ranked_phrases)
+        self.assertEqual([phrase for _, phrase in r.get_ranked_phrases_with_scores()], ranked_phrases)
 
 
 if __name__ == '__main__':

--- a/tests/rake_test.py
+++ b/tests/rake_test.py
@@ -53,6 +53,7 @@ class RakeUnitTest(unittest.TestCase):
                        ['define'], ['sequence'], ['one'], ['words'],
                        ['provide'], ['compact', 'representation'], ['document'],
                        ['content']]
+        phrase_list = set(tuple(phrase) for phrase in phrase_list)
         self.assertEqual(r._generate_phrases(sentences), phrase_list)
 
     def test_get_phrase_list_from_words(self):
@@ -60,6 +61,7 @@ class RakeUnitTest(unittest.TestCase):
 
         word_list = ['red', 'apples', ",", 'are', 'good', 'in', 'flavour']
         phrase_list = [['red', 'apples'], ['good'], ['flavour']]
+        phrase_list = list(tuple(phrase) for phrase in phrase_list)
         self.assertEqual(r._get_phrase_list_from_words(word_list), phrase_list)
 
         word_list = ['keywords', ",", 'which', 'we', 'define', 'as', 'a',
@@ -69,6 +71,7 @@ class RakeUnitTest(unittest.TestCase):
         phrase_list = [['keywords'], ['define'], ['sequence'], ['one'],
                        ['words'], ['provide'], ['compact', 'representation'],
                        ['document'], ['content']]
+        phrase_list = list(tuple(phrase) for phrase in phrase_list)
         self.assertEqual(r._get_phrase_list_from_words(word_list), phrase_list)
 
     def test_extract_keywords_from_text(self):

--- a/tests/rake_test.py
+++ b/tests/rake_test.py
@@ -49,29 +49,26 @@ class RakeUnitTest(unittest.TestCase):
             'Keywords, which we define as a sequence of one or more words, ' +
             'provide a compact representation of a document\'s content'
         ]
-        phrase_list = [['red', 'apples'], ['good'], ['flavour'], ['keywords'],
-                       ['define'], ['sequence'], ['one'], ['words'],
-                       ['provide'], ['compact', 'representation'], ['document'],
-                       ['content']]
-        phrase_list = set(tuple(phrase) for phrase in phrase_list)
+        phrase_list = {('red', 'apples'), ('good',), ('flavour',), ('keywords',),
+                       ('define',), ('sequence',), ('one',), ('words',),
+                       ('provide',), ('compact', 'representation'), ('document',),
+                       ('content',)}
         self.assertEqual(r._generate_phrases(sentences), phrase_list)
 
     def test_get_phrase_list_from_words(self):
         r = Rake()
 
         word_list = ['red', 'apples', ",", 'are', 'good', 'in', 'flavour']
-        phrase_list = [['red', 'apples'], ['good'], ['flavour']]
-        phrase_list = list(tuple(phrase) for phrase in phrase_list)
+        phrase_list = [('red', 'apples'), ('good',), ('flavour',)]
         self.assertEqual(r._get_phrase_list_from_words(word_list), phrase_list)
 
         word_list = ['keywords', ",", 'which', 'we', 'define', 'as', 'a',
                      'sequence', 'of', 'one', 'or', 'more', 'words', ",",
                      'provide', 'a', 'compact', 'representation', 'of', 'a',
                      'document', '\'', 's', 'content']
-        phrase_list = [['keywords'], ['define'], ['sequence'], ['one'],
-                       ['words'], ['provide'], ['compact', 'representation'],
-                       ['document'], ['content']]
-        phrase_list = list(tuple(phrase) for phrase in phrase_list)
+        phrase_list = [('keywords',), ('define',), ('sequence',), ('one',),
+                       ('words',), ('provide',), ('compact', 'representation'),
+                       ('document',), ('content',)]
         self.assertEqual(r._get_phrase_list_from_words(word_list), phrase_list)
 
     def test_extract_keywords_from_text(self):


### PR DESCRIPTION
Hi, and thanks for writing the RAKE algorithm using NLTK.

I've noticed in the code that you keep phrases as lists of words, which then makes it more difficult to compute the list of unique phrases. What I changed was to use tuples instead of lists, then the list of phrases can be a set instead and you get unique phrases with less code, and faster as well.