### PR TITLE
Add a feature to limit min and max phrase length  + resolve issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ r = Rake(
 r = Rake(ranking_metric=Metric.DEGREE_TO_FREQUENCY_RATIO)
 r = Rake(ranking_metric=Metric.WORD_DEGREE)
 r = Rake(ranking_metric=Metric.WORD_FREQUENCY)
+
+# If you want to control the max or min words length in all ranked phrases, 
+# you can initialize a Rake instance as below:
+
+r = Rake(min_length=2, max_length=4)
 ```
 
 ## References

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,10 @@ Advanced Usage
     r = Rake(ranking_metric=Metric.WORD_DEGREE)
     r = Rake(ranking_metric=Metric.WORD_FREQUENCY)
 
+    # If you want to control the max or min words length in all ranked phrases,
+    # you can initialize a Rake instance as below:
+
+    r = Rake(min_length=2, max_length=4)
 References
 ----------
 

--- a/rake_nltk/rake.py
+++ b/rake_nltk/rake.py
@@ -31,7 +31,7 @@ class Rake(object):
         punctuations=None,
         language="english",
         ranking_metric=Metric.DEGREE_TO_FREQUENCY_RATIO,
-        max_length=5,
+        max_length=100000,
         min_length=1,
     ):
         """Constructor.
@@ -39,6 +39,8 @@ class Rake(object):
         :param stopwords: List of Words to be ignored for keyword extraction.
         :param punctuations: Punctuations to be ignored for keyword extraction.
         :param language: Language to be used for stopwords
+        :param max_length: Maximum limit of the number of words in a phrase
+        :param min_length: Minimum limit of the number of words in a phrase
         """
         # By default use degree to frequency ratio as the metric.
         if isinstance(ranking_metric, Metric):
@@ -190,8 +192,8 @@ class Rake(object):
     def _get_phrase_list_from_words(self, word_list):
         """Method to create contender phrases from the list of words that form
         a sentence by dropping stopwords and punctuations and grouping the left
-        words into phrases. All the phrases should have a length in the range
-        [self.min_length, self.max_length]. Ex:
+        words into phrases. Only phrases in the given range would be considered
+        to build co-occurrence matrix. Ex:
 
         Sentence: Red apples, are good in flavour.
         List of words: ['red', 'apples', ",", 'are', 'good', 'in', 'flavour']
@@ -211,5 +213,5 @@ class Rake(object):
         """
         groups = groupby(word_list, lambda x: x not in self.to_ignore)
         phrases = [tuple(group[1]) for group in groups if group[0]]
-        return [phrase for phrase in phrases
-                if self.min_length <= len(phrase) <= self.max_length]
+        return list(filter(
+            lambda x: self.min_length <= len(x) <= self.max_length, phrases))

--- a/tests/rake_test.py
+++ b/tests/rake_test.py
@@ -72,6 +72,23 @@ class RakeUnitTest(unittest.TestCase):
         }
         self.assertEqual(r._generate_phrases(sentences), phrase_list)
 
+    def test_generate_phrases_with_length_limit(self):
+        r = Rake(min_length=2, max_length=4)
+
+        sentences = [
+            "Red apples, are good in flavour.",
+            "Keywords, which we define as a sequence of one or more words, "
+            + "provide a compact representation of a document's content",
+            "Criteria of compatibility of a system of linear Diophantine "
+            + "equations",
+        ]
+        phrase_list = {
+            ("red", "apples"),
+            ("compact", "representation"),
+            ("linear", "diophantine", "equations"),
+        }
+        self.assertEqual(r._generate_phrases(sentences), phrase_list)
+
     def test_get_phrase_list_from_words(self):
         r = Rake()
 

--- a/tests/rake_test.py
+++ b/tests/rake_test.py
@@ -55,6 +55,11 @@ class RakeUnitTest(unittest.TestCase):
             "Red apples, are good in flavour.",
             "Keywords, which we define as a sequence of one or more words, "
             + "provide a compact representation of a document's content",
+            "Criteria of compatibility of a system of linear Diophantine "
+            + "equations",
+            "whose gloomy beams transfigured the village into a lunar "
+            + "encampment of glowing houses and streets of volcanic deserts "
+            + "every fifteen seconds "
         ]
         phrase_list = {
             ("red", "apples"),
@@ -69,6 +74,16 @@ class RakeUnitTest(unittest.TestCase):
             ("compact", "representation"),
             ("document",),
             ("content",),
+            ("criteria",),
+            ("compatibility",),
+            ("system",),
+            ("linear", "diophantine", "equations"),
+            ("whose", "gloomy", "beams", "transfigured"),
+            ("volcanic", "deserts", "every", "fifteen", "seconds"),
+            ("lunar", "encampment"),
+            ("glowing", "houses"),
+            ("village",),
+            ("streets",),
         }
         self.assertEqual(r._generate_phrases(sentences), phrase_list)
 
@@ -81,11 +96,23 @@ class RakeUnitTest(unittest.TestCase):
             + "provide a compact representation of a document's content",
             "Criteria of compatibility of a system of linear Diophantine "
             + "equations",
+            "whose gloomy beams transfigured the village into a lunar "
+            + "encampment of glowing houses and streets of volcanic deserts "
+            + "every fifteen seconds "
         ]
         phrase_list = {
             ("red", "apples"),
             ("compact", "representation"),
             ("linear", "diophantine", "equations"),
+            ("whose", "gloomy", "beams", "transfigured"),
+            ("lunar", "encampment",),
+            ("glowing", "houses",),
+        }
+        self.assertEqual(r._generate_phrases(sentences), phrase_list)
+
+        r = Rake(min_length=5, max_length=5)
+        phrase_list = {
+            ("volcanic", "deserts", "every", "fifteen", "seconds",),
         }
         self.assertEqual(r._generate_phrases(sentences), phrase_list)
 


### PR DESCRIPTION
This is a pull request to resolve the [issue #4](https://github.com/csurfer/rake-nltk/issues/4)

The length limit should be applied before building the co-occurence matrix. 
Otherwise, we count meaningless phrases in the co-occurence matrix, and this could lead to a wrong ranked phrase list. Not only scores, order could also be influenced.