### PR TITLE
Don't fail if nltk downloads don't work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,14 @@ with open(path.join(here, "README.rst")) as f:
 
 
 def _post_install():
-    """Post installation nltk corpus downloads."""
-    import nltk
+    try:
+        """Post installation nltk corpus downloads."""
+        import nltk
 
-    nltk.download("punkt")
-    nltk.download("stopwords")
+        nltk.download("punkt")
+        nltk.download("stopwords")
+    except:
+        pass
 
 
 class PostDevelop(develop):


### PR DESCRIPTION
hi @csurfer, thanks for your work here!

I found I had to make this change in order to be able to be able to install the package as part of a serverless app to deploy on AWS lambda. In that context it doesn't really make sense to force download the NLTK data as part of the install of your package. In fact, the install failed because it didn't have access to nlltk at build time.