### PR TITLE
fix: Set default tokenizer language to actual language parameter.

### DIFF
--- a/rake_nltk/rake.py
+++ b/rake_nltk/rake.py
@@ -8,6 +8,7 @@ documents` by Stuart Rose, Dave Engel, Nick Cramer and Wendy Cowley.
 import string
 from collections import Counter, defaultdict
 from enum import Enum
+from functools import partial
 from itertools import chain, groupby, product
 from typing import Callable, DefaultDict, Dict, List, Optional, Set, Tuple
 
@@ -105,7 +106,7 @@ class Rake:
         if sentence_tokenizer:
             self.sentence_tokenizer = sentence_tokenizer
         else:
-            self.sentence_tokenizer = nltk.tokenize.sent_tokenize
+            self.sentence_tokenizer = partial(nltk.tokenize.sent_tokenize, language=language)
         self.word_tokenizer: Callable[[str], List[str]]
         if word_tokenizer:
             self.word_tokenizer = word_tokenizer


### PR DESCRIPTION
Currently, the default tokenizer (nltk.tokenize.sent_tokenize) is not using the language set in the constructor, but the default language as set in nltk.tokenize.sent_tokenize method, which is english (see https://www.nltk.org/api/nltk.tokenize.html#nltk.tokenize.sent_tokenize).
This is a simple fix that sets the default tokenizer as the nlkt tokenize function but changing the default language parameter to the one set by the user in Rake constructor.

Note that the word tokenizer does not need the change as nltk.tokenize.wordpunct_tokenize is language agnostic.